### PR TITLE
Rename alias_method_chain

### DIFF
--- a/lib/clipboard_image_paste/attachment_patch.rb
+++ b/lib/clipboard_image_paste/attachment_patch.rb
@@ -22,7 +22,9 @@ module AttachmentPatch
       unloadable
 
       #~ alias_method_chain :attach_files, :pasted_images
-      alias_method_chain :save_attachments, :pasted_images
+      #~ alias_method_chain :save_attachments, :pasted_images
+      alias_method :save_attachmenets_without_pasted_images, :save_attachments
+      alias_method :save_attachments, :save_attachments_with_pasted_images
     end
   end
 


### PR DESCRIPTION
`alias_method_chain` was removed in [Rails 5.1](https://apidock.com/rails/Module/alias_method_chain) and must be migrated to old_school `alias_method`.

This makes the plugin work with Redmine 4.0 with Rails > 5.0 work again